### PR TITLE
global options variable test fails if $erroractionpreference = "stop"

### DIFF
--- a/PoshRSJob/Scripts/TabExpansion.ps1
+++ b/PoshRSJob/Scripts/TabExpansion.ps1
@@ -17,7 +17,7 @@ $completion_Name = {
     }
 }
 #endregion Job Name
-If (-not $global:options) { 
+If (-not (Get-Variable -Scope Global -Name Options -ErrorAction:SilentlyContinue)) { 
     $global:options = @{
         CustomArgumentCompleters = @{}
         NativeArgumentCompleters = @{}


### PR DESCRIPTION
Switched to do a Get-Variable test.