### PR TITLE
#59 hasmoredata doesn't get modified after receive-rsjob

### DIFF
--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -100,6 +100,7 @@ Function Receive-RSJob {
     Process {
         If (-NOT $Bound -and $InputObject) {
             $_ | WriteStream
+            $_.HasMoreData = $false
         }
         elseif (-Not $Bound) {
             [void]$List.Add($_)
@@ -133,11 +134,16 @@ Function Receive-RSJob {
         Write-Verbose "ScriptBlock: $($ScriptBlock)"
         If ($ScriptBlock) {
             Write-Verbose "Running Scriptblock"
-            $PoshRS_jobs | Where $ScriptBlock | WriteStream
+            $PoshRS_jobs | Where $ScriptBlock | %{ 
+                WriteStream
+                $_.HasMoreData = $false
+            }
         } ElseIf ($Bound) {
-            $PoshRS_jobs | WriteStream
+            $PoshRS_jobs | %{ 
+                WriteStream
+                $_.HasMoreData = $false
+            }
         }
     }
 }
-
 


### PR DESCRIPTION
Test:

```
(Get-RSJob | Remove-RSJob); [void] (Start-RSJob -ScriptBlock { Get-ChildItem }); Start-Sleep -Seconds 1; [void] (Get-RSJob | Receive-RSJob); Get-RSJob | Where { $_.HasMoreData }
```

It should not return anything. It does.