### PR TITLE
fix issue #59 set hasmoredata after complete and received

### DIFF
--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -100,6 +100,7 @@ Function Receive-RSJob {
     Process {
         If (-NOT $Bound -and $InputObject) {
             $_ | WriteStream
+            if (@("Completed", "Failed", "Stopped") -contains $_.State) { $_.HasMoreData = $false }
         }
         elseif (-Not $Bound) {
             [void]$List.Add($_)
@@ -133,11 +134,16 @@ Function Receive-RSJob {
         Write-Verbose "ScriptBlock: $($ScriptBlock)"
         If ($ScriptBlock) {
             Write-Verbose "Running Scriptblock"
-            $PoshRS_jobs | Where $ScriptBlock | WriteStream
+            $PoshRS_jobs | Where $ScriptBlock | %{ 
+                $_ | WriteStream
+                if (@("Completed", "Failed", "Stopped") -contains $_.State) { $_.HasMoreData = $false }
+            }
         } ElseIf ($Bound) {
-            $PoshRS_jobs | WriteStream
+            $PoshRS_jobs | %{ 
+                $_ | WriteStream
+                if (@("Completed", "Failed", "Stopped") -contains $_.State) { $_.HasMoreData = $false }
+            }
         }
     }
 }
-
 


### PR DESCRIPTION
HasMoreData can be cleared after a receive where the state is in Completed, Failed, or Stopped.

```
Import-Module PoshRSJob -Force

Get-RSJob | Remove-RSJob -Force
[void] (Start-RSJob -ScriptBlock { Get-ChildItem })
Start-Sleep -Seconds 1
[void] (Get-RSJob | Receive-RSJob)
Get-RSJob | Where { $_.HasMoreData }
```